### PR TITLE
Introducing dokka-paparazzi's Gradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   kotlin("jvm") version "2.0.0"
   id("com.diffplug.spotless") version "6.25.0"
+  id("com.vanniktech.maven.publish") version "0.29.0" apply false
   idea
 }
 
@@ -73,7 +74,11 @@ allprojects {
   tasks.withType<KotlinCompile> {
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
-      optIn.addAll("kotlin.OptIn", "kotlin.RequiresOptIn")
+      optIn.addAll(
+        "kotlin.OptIn",
+        "kotlin.RequiresOptIn",
+        "kotlin.contracts.ExperimentalContracts",
+      )
     }
   }
 }
@@ -86,5 +91,5 @@ subprojects {
 }
 
 tasks.register<Delete>("cleanAll") {
-  allprojects.map { project -> project.layout.buildDirectory }.forEach(::delete)
+  delete(*allprojects.map { project -> project.layout.buildDirectory }.toTypedArray())
 }

--- a/dokka-integration-test/README.md
+++ b/dokka-integration-test/README.md
@@ -1,0 +1,4 @@
+## Prerequisite
+
+- `./gradlew :dokkapaparazzi-plugin:publishToMavenLocal`
+- `./gradlew :gradle-plugin:publishToMavenLocal`

--- a/dokka-integration-test/build.gradle.kts
+++ b/dokka-integration-test/build.gradle.kts
@@ -11,11 +11,7 @@ plugins {
   // TODO
   //  val dokkaVersion: String by rootProject.properties
   id("org.jetbrains.dokka") version "1.9.20"
-
-  // Prerequisite:
-  //   - `./gradlew :dokkapaparazzi-plugin:publishToMavenLocal`
-  //   - `./gradlew :gradle-plugin:publishToMavenLocal`
-  id("land.sungbin.dokkapaparazzi") version "0.1.0"
+  id("land.sungbin.dokka-paparazzi") version "0.1.0"
 }
 
 val removeOldOutputTask = tasks.create<Delete>("removeOldOutput") {

--- a/dokka-integration-test/build.gradle.kts
+++ b/dokka-integration-test/build.gradle.kts
@@ -7,7 +7,15 @@
 
 plugins {
   kotlin("jvm")
+
+  // TODO
+  //  val dokkaVersion: String by rootProject.properties
   id("org.jetbrains.dokka") version "1.9.20"
+
+  // Prerequisite:
+  //   - `./gradlew :dokkapaparazzi-plugin:publishToMavenLocal`
+  //   - `./gradlew :gradle-plugin:publishToMavenLocal`
+  id("land.sungbin.dokkapaparazzi") version "0.1.0"
 }
 
 val removeOldOutputTask = tasks.create<Delete>("removeOldOutput") {
@@ -17,15 +25,8 @@ val removeOldOutputTask = tasks.create<Delete>("removeOldOutput") {
 tasks.dokkaHtml {
   dependsOn(removeOldOutputTask)
   outputDirectory = projectDir.resolve("output")
-  pluginsMapConfiguration = mapOf(
-    "land.sungbin.dokkapaparazzi.DokkaPaparazziPlugin" to """
-      |{
-      |  "snapshotImageDir": "${projectDir.resolve("snapshots")}"
-      |}
-    """.trimMargin(),
-  )
 }
 
-dependencies {
-  dokkaPlugin(projects.dokkapaparazziPlugin)
+dokkaPaparazzi {
+  snapshotDir = projectDir.resolve("snapshots")
 }

--- a/dokkapaparazzi-plugin/build.gradle.kts
+++ b/dokkapaparazzi-plugin/build.gradle.kts
@@ -5,31 +5,24 @@
  * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
   kotlin("jvm")
+  id("com.vanniktech.maven.publish")
 }
 
 kotlin {
   compilerOptions {
-    jvmTarget = JvmTarget.JVM_17
     optIn.addAll(
       "org.jetbrains.dokka.InternalDokkaApi",
       "org.jetbrains.dokka.plugability.DokkaPluginApiPreview",
-      "kotlin.contracts.ExperimentalContracts",
     )
   }
 }
 
-tasks.test {
-  useJUnitPlatform()
-}
+// TODO https://github.com/Kotlin/dokka/issues/2812
+val dokkaVersion: String by rootProject.properties
 
 dependencies {
-  // TODO https://github.com/Kotlin/dokka/issues/2812
-  val dokkaVersion = "1.9.20"
-
   compileOnly("org.jetbrains.dokka:dokka-core:$dokkaVersion")
   implementation("org.jetbrains.dokka:dokka-base:$dokkaVersion")
   implementation("org.jetbrains.kotlinx:kotlinx-html:0.11.0")

--- a/dokkapaparazzi-plugin/gradle.properties
+++ b/dokkapaparazzi-plugin/gradle.properties
@@ -1,0 +1,2 @@
+POM_NAME=Dokka Paparazzi Dokka Plugin
+POM_ARTIFACT_ID=dokka-paparazzi

--- a/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotAwareKotlinSignatureProvider.kt
+++ b/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotAwareKotlinSignatureProvider.kt
@@ -45,7 +45,7 @@ class SnapshotAwareKotlinSignatureProvider(context: DokkaContext) : SignaturePro
 
     val values = Gson().fromJson<Map<String, String>>(configuration.values, object : TypeToken<Map<String, String>>() {}.type)
     val path = checkNotNull(values[SnapshotImageProvider.CONFIGURATION_PATH_KEY]) {
-      "The 'snapshotImageDir' field in the 'land.sungbin.dokkapaparazzi.DokkaPaparazziPlugin' Dokka configuration is missing."
+      "The 'snapshotDir' field in the 'land.sungbin.dokkapaparazzi.DokkaPaparazziPlugin' Dokka configuration is missing."
     }
 
     snapshotImageProvider = SnapshotImageProvider(path.toPath())

--- a/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotAwareKotlinSignatureProvider.kt
+++ b/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotAwareKotlinSignatureProvider.kt
@@ -49,6 +49,7 @@ class SnapshotAwareKotlinSignatureProvider(context: DokkaContext) : SignaturePro
     }
 
     snapshotImageProvider = SnapshotImageProvider(path.toPath())
+    logger.progress("The DokkaPaparazzi plugin has been successfully added with the snapshot path \"$path\".")
   }
 
   override fun signature(documentable: Documentable): List<ContentNode> {

--- a/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotImageProvider.kt
+++ b/dokkapaparazzi-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/SnapshotImageProvider.kt
@@ -39,7 +39,7 @@ class SnapshotImageProvider(
   }
 
   companion object {
-    const val CONFIGURATION_PATH_KEY = "snapshotImageDir"
+    const val CONFIGURATION_PATH_KEY = "snapshotDir"
 
     /** @snapshotname a,b,c */
     const val TAG_NAME_ANNOTATION = "snapshotname"

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -21,11 +21,14 @@ val functionalTestTask = tasks.register<Test>(functionalTest.name) {
   mustRunAfter(tasks.test)
 }
 
+@Suppress("UnstableApiUsage")
 gradlePlugin {
   testSourceSets(functionalTest)
   plugins {
     create("dokkaPaparazziGradle") {
-      id = "land.sungbin.dokkapaparazzi"
+      id = "land.sungbin.dokka-paparazzi"
+      tags = listOf("dokka", "dokka-plugin")
+      description = "Connect Dokka with screenshot-testing libraries."
       implementationClass = "land.sungbin.dokkapaparazzi.gradle.DokkaPaparazziGradlePlugin"
     }
   }
@@ -53,11 +56,13 @@ val dokkaVersion: String by rootProject.properties
 dependencies {
   compileOnly(gradleApi())
   compileOnly(projects.dokkapaparazziPlugin)
-  compileOnly("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
+
+  implementation("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
   implementation("com.google.code.gson:gson:2.11.0")
 
   "functionalTestImplementation"(kotlin("test-junit5"))
   "functionalTestImplementation"(gradleTestKit())
+  "functionalTestImplementation"("com.willowtreeapps.assertk:assertk:0.28.1")
 }
 
 abstract class UpdatePluginVersionTask : DefaultTask() {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,0 +1,78 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+ */
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+  kotlin("jvm")
+  `kotlin-dsl`
+  `java-gradle-plugin`
+  id("com.vanniktech.maven.publish")
+}
+
+val functionalTest: SourceSet by sourceSets.creating
+val functionalTestTask = tasks.register<Test>(functionalTest.name) {
+  group = LifecycleBasePlugin.VERIFICATION_GROUP
+  testClassesDirs = functionalTest.output.classesDirs
+  classpath = functionalTest.runtimeClasspath
+  mustRunAfter(tasks.test)
+}
+
+gradlePlugin {
+  testSourceSets(functionalTest)
+  plugins {
+    create("dokkaPaparazziGradle") {
+      id = "land.sungbin.dokkapaparazzi"
+      implementationClass = "land.sungbin.dokkapaparazzi.gradle.DokkaPaparazziGradlePlugin"
+    }
+  }
+}
+
+tasks.check {
+  dependsOn(functionalTestTask)
+}
+
+val updatePluginVersion = tasks.register<UpdatePluginVersionTask>("updatePluginVersion") {
+  version.set(rootProject.properties.getValue("VERSION_NAME") as String)
+  destination.set(projectDir.walk().first { path -> path.endsWith("VERSION.kt") })
+}
+
+tasks
+  .matching { task -> task.name == "sourcesJar" || task.name == "spotlessKotlin" }
+  .configureEach { dependsOn(updatePluginVersion) }
+
+tasks.withType<KotlinCompile>().configureEach {
+  dependsOn(updatePluginVersion)
+}
+
+val dokkaVersion: String by rootProject.properties
+
+dependencies {
+  compileOnly(gradleApi())
+  compileOnly(projects.dokkapaparazziPlugin)
+  compileOnly("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
+  implementation("com.google.code.gson:gson:2.11.0")
+
+  "functionalTestImplementation"(kotlin("test-junit5"))
+  "functionalTestImplementation"(gradleTestKit())
+}
+
+abstract class UpdatePluginVersionTask : DefaultTask() {
+  @get:Input abstract val version: Property<String>
+
+  @get:InputFile abstract val destination: RegularFileProperty
+
+  @TaskAction fun run() {
+    val packageLine = destination.get().asFile.useLines { it.first { line -> line.startsWith("package") } }
+    destination.get().asFile.writeText(
+      """
+      $packageLine
+
+      const val PLUGIN_VERSION = "${version.get()}"
+      """.trimIndent(),
+    )
+  }
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
   "functionalTestImplementation"(kotlin("test-junit5"))
   "functionalTestImplementation"(gradleTestKit())
   "functionalTestImplementation"("com.willowtreeapps.assertk:assertk:0.28.1")
+  "functionalTestImplementation"("org.jsoup:jsoup:1.18.1")
 }
 
 abstract class UpdatePluginVersionTask : DefaultTask() {

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,0 +1,2 @@
+POM_NAME=Dokka Paparazzi Gradle Plugin
+POM_ARTIFACT_ID=dokka-paparazzi-gradle

--- a/gradle-plugin/src/functionalTest/README.md
+++ b/gradle-plugin/src/functionalTest/README.md
@@ -1,0 +1,3 @@
+## Prerequisite
+
+- `./gradlew :dokkapaparazzi-plugin:publishToMavenLocal`

--- a/gradle-plugin/src/functionalTest/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePluginTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePluginTest.kt
@@ -1,0 +1,158 @@
+package land.sungbin.dokkapaparazzi.gradle
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.contains
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createDirectory
+import kotlin.io.path.createFile
+import kotlin.io.path.notExists
+import kotlin.io.path.writeText
+import kotlin.random.Random
+import kotlin.test.Test
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.BeforeEach
+
+class DokkaPaparazziGradlePluginTest {
+  // @field:TempDir
+  lateinit var projectDir: Path
+
+  private lateinit var moduleDir: Path
+
+  private lateinit var projectSettingsFile: Path
+  private lateinit var projectBuildFile: Path
+  private lateinit var moduleBuildFile: Path
+
+  @BeforeEach fun setup() {
+    projectDir = Path.of("/Users/jisungbin/IdeaProjects/test").resolve(Random.nextInt().toString())
+
+    projectSettingsFile = projectDir.resolve("settings.gradle.kts").ensureFileCreated()
+    projectBuildFile = projectDir.resolve("build.gradle.kts").ensureFileCreated()
+    moduleDir = projectDir.resolve("test").createDirectory()
+    moduleBuildFile = moduleDir.resolve("build.gradle.kts").ensureFileCreated()
+
+    projectBuildFile.writeText(
+      """
+      plugins {
+        kotlin("jvm") version "2.0.0"
+      }
+      """.trimIndent(),
+    )
+  }
+
+  @Test fun withoutDokkaPluginThenErrors() {
+    touchSettingsFile(projectName = "withoutDokkaPluginThenErrors")
+    moduleBuildFile.writeText(
+      """
+      plugins {
+        kotlin("jvm")
+        ${dokkaPaparazziPlugin()}
+      }
+      """.trimIndent(),
+    )
+
+    val result = runner().withArguments(":test:dokkaHtml").buildAndFail()
+
+    assertThat(result.output).all {
+      contains("Failed to apply plugin 'land.sungbin.dokka-paparazzi'")
+      contains("Dokka plugin is not applied")
+    }
+  }
+
+  @Test fun snapshotDirShouldPresentWhenRunDokkaTask() {
+    touchSettingsFile(projectName = "snapshotDirShouldPresentWhenRunDokkaTask")
+    moduleBuildFile.writeText(
+      """
+      plugins {
+        kotlin("jvm")
+        ${dokkaPlugin()}
+        ${dokkaPaparazziPlugin()}
+      }
+      
+      dokkaPaparazzi {
+        // Nothing to do  
+      }
+      """.trimIndent(),
+    )
+
+    runner().withArguments(":test:build").build()
+    val result = runner().withArguments(":test:dokkaHtml").buildAndFail()
+
+    assertThat(result.output).all {
+      contains("Failed to calculate the value of task ':test:dokkaHtml' property 'pluginsMapConfiguration'")
+      contains("'snapshotDir' is not set")
+    }
+  }
+
+  @Test fun snapshotDirWithDokkaPluginThenWorksFine() {
+    touchSettingsFile(projectName = "snapshotDirWithDokkaPluginThenBuildSuccess")
+    moduleBuildFile.writeText(
+      """
+      plugins {
+        kotlin("jvm")
+        ${dokkaPlugin()}
+        ${dokkaPaparazziPlugin()}
+      }
+      
+      dokkaPaparazzi {
+        snapshotDir = projectDir.resolve("snapshots")
+      }
+      """.trimIndent(),
+    )
+
+    moduleDir.resolve("snapshots").createDirectory()
+    moduleDir
+      .resolve("src/main/kotlin").also(Path::createDirectories)
+      .resolve("Hello.kt").also(Path::createFile)
+      .writeText(
+        """
+        /**
+         * Hello, Dokka!
+         */
+        fun hello() = Unit
+        """.trimIndent(),
+      )
+
+    val result = runner().withArguments(":test:dokkaHtml").build()
+    println(result.output)
+  }
+
+  private fun runner(): GradleRunner =
+    GradleRunner.create()
+      .withProjectDir(projectDir.toFile())
+      .withPluginClasspath()
+
+  private fun dokkaPlugin() = """id("org.jetbrains.dokka") version "1.9.20""""
+  private fun dokkaPaparazziPlugin() = """id("land.sungbin.dokka-paparazzi") version "0.1.0""""
+
+  private fun touchSettingsFile(projectName: String) {
+    val code = """
+      rootProject.name = "$projectName"
+      
+      pluginManagement {
+        repositories {
+          mavenCentral()
+          gradlePluginPortal()
+          mavenLocal()
+        }
+      }
+
+      dependencyResolutionManagement {
+        repositories {
+          mavenCentral()
+          mavenLocal()
+        }
+      }
+      
+      include(":test")
+    """.trimIndent()
+    projectSettingsFile.writeText(code)
+  }
+
+  private fun Path.ensureFileCreated(): Path = apply {
+    // TODO why Path.createParentDirectories() is not available?
+    if (parent?.notExists() == true) parent!!.createDirectories()
+    if (notExists()) createFile()
+  }
+}

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziExtension.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziExtension.kt
@@ -1,0 +1,15 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+ */
+
+package land.sungbin.dokkapaparazzi.gradle
+
+import javax.inject.Inject
+import org.gradle.api.model.ObjectFactory
+
+abstract class DokkaPaparazziExtension @Inject constructor(objects: ObjectFactory) {
+  val snapshotDir = objects.directoryProperty()
+}

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePlugin.kt
@@ -1,0 +1,52 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+ */
+
+package land.sungbin.dokkapaparazzi.gradle
+
+import com.google.gson.Gson
+import land.sungbin.dokkapaparazzi.DokkaPaparazziPlugin
+import land.sungbin.dokkapaparazzi.SnapshotImageProvider
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.dokka.gradle.AbstractDokkaTask
+import org.jetbrains.dokka.gradle.DokkaPlugin
+
+@Suppress("unused") // Used by reflection in Gradle.
+class DokkaPaparazziGradlePlugin : Plugin<Project> {
+  override fun apply(target: Project) {
+    check(target.plugins.hasPlugin(DokkaPlugin::class.java)) {
+      "Dokka plugin is not applied."
+    }
+
+    val extension = target.extensions.create<DokkaPaparazziExtension>("dokkaPaparazzi")
+
+    target.afterEvaluate {
+      target.dependencies.add(
+        "dokkaPlugin",
+        target.dependencies.create("land.sungbin.dokkapaparazzi:dokka-paparazzi:$PLUGIN_VERSION"),
+      )
+
+      target.tasks.withType<AbstractDokkaTask> {
+        pluginsMapConfiguration.put(
+          DokkaPaparazziPlugin.PLUGIN_NAME,
+          provider {
+            check(extension.snapshotDir.isPresent) { "snapshotDir is not set." }
+            val path = extension.snapshotDir.get().asFile.path
+            val configuration = mapOf(SnapshotImageProvider.CONFIGURATION_PATH_KEY to path)
+            gson.toJson(configuration)
+          },
+        )
+      }
+    }
+  }
+
+  companion object {
+    private val gson = Gson()
+  }
+}

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/DokkaPaparazziGradlePlugin.kt
@@ -15,12 +15,11 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.AbstractDokkaTask
-import org.jetbrains.dokka.gradle.DokkaPlugin
 
 @Suppress("unused") // Used by reflection in Gradle.
 class DokkaPaparazziGradlePlugin : Plugin<Project> {
   override fun apply(target: Project) {
-    check(target.plugins.hasPlugin(DokkaPlugin::class.java)) {
+    check(target.plugins.hasPlugin("org.jetbrains.dokka")) {
       "Dokka plugin is not applied."
     }
 
@@ -36,7 +35,7 @@ class DokkaPaparazziGradlePlugin : Plugin<Project> {
         pluginsMapConfiguration.put(
           DokkaPaparazziPlugin.PLUGIN_NAME,
           provider {
-            check(extension.snapshotDir.isPresent) { "snapshotDir is not set." }
+            check(extension.snapshotDir.isPresent) { "'snapshotDir' is not set." }
             val path = extension.snapshotDir.get().asFile.path
             val configuration = mapOf(SnapshotImageProvider.CONFIGURATION_PATH_KEY to path)
             gson.toJson(configuration)

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
@@ -1,10 +1,3 @@
-/*
- * Developed by Ji Sungbin 2024.
- *
- * Licensed under the MIT.
- * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
- */
-
 package land.sungbin.dokkapaparazzi.gradle
 
 const val PLUGIN_VERSION = "0.1.0"

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
@@ -1,3 +1,10 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+ */
+
 package land.sungbin.dokkapaparazzi.gradle
 
 const val PLUGIN_VERSION = "0.1.0"

--- a/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
+++ b/gradle-plugin/src/main/kotlin/land/sungbin/dokkapaparazzi/gradle/VERSION.kt
@@ -1,0 +1,10 @@
+/*
+ * Developed by Ji Sungbin 2024.
+ *
+ * Licensed under the MIT.
+ * Please see full license: https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+ */
+
+package land.sungbin.dokkapaparazzi.gradle
+
+const val PLUGIN_VERSION = "0.1.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,31 @@ org.gradle.configuration-cache=true
 kotlin.code.style=official
 kotlin.build.report.output=json
 kotlin.build.report.json.directory=.kotlin
+
+dokkaVersion=1.9.20
+
+# ---------- POM ---------- #
+
+SONATYPE_HOST=CENTRAL_PORTAL
+RELEASE_SIGNING_ENABLED=true
+SONATYPE_AUTOMATIC_RELEASE=true
+
+GROUP=land.sungbin.dokkapaparazzi
+VERSION_NAME=0.1.0
+
+POM_DESCRIPTION=Connect Dokka with screenshot-testing libraries
+POM_INCEPTION_YEAR=2024
+POM_URL=https://github.com/jisungbin/dokka-paparazzi
+
+POM_LICENSE_NAME=MIT License
+POM_LICENSE_URL=https://github.com/jisungbin/dokka-paparazzi/blob/main/LICENSE
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/jisungbin/dokka-paparazzi/tree/main
+POM_SCM_CONNECTION=scm:git:github.com/jisungbin/dokka-paparazzi.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://github.com/jisungbin/dokka-paparazzi.git
+
+POM_DEVELOPER_ID=jisungbin
+POM_DEVELOPER_NAME=Ji Sungbin
+POM_DEVELOPER_URL=https://sungb.in
+POM_DEVELOPER_EMAIL=ji@sungb.in

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ pluginManagement {
     }
     mavenCentral()
     gradlePluginPortal()
+    mavenLocal()
   }
 }
 
@@ -37,10 +38,12 @@ dependencyResolutionManagement {
       }
     }
     mavenCentral()
+    mavenLocal()
   }
 }
 
 include(
-  "dokkapaparazzi-plugin",
-  "dokka-integration-test",
+  ":gradle-plugin",
+  ":dokkapaparazzi-plugin",
+  ":dokka-integration-test",
 )


### PR DESCRIPTION
Since dokka-paparazzi requires the Dokka configuration of the snapshot path to work, adding a Gradle plugin makes it easy.